### PR TITLE
Update ProductAbstractListTermToProductAbstractListTypeExecutor.php

### DIFF
--- a/src/Spryker/Client/ContentProduct/Executor/ProductAbstractListTermToProductAbstractListTypeExecutor.php
+++ b/src/Spryker/Client/ContentProduct/Executor/ProductAbstractListTermToProductAbstractListTypeExecutor.php
@@ -25,7 +25,7 @@ class ProductAbstractListTermToProductAbstractListTypeExecutor implements Conten
         );
 
         $contentProductAbstractListTypeTransfer = new ContentProductAbstractListTypeTransfer();
-        $contentProductAbstractListTypeTransfer->setIdProductAbstracts($contentProductAbstractListTermTransfer->getIdProductAbstracts());
+        $contentProductAbstractListTypeTransfer->fromArray($contentProductAbstractListTermTransfer->toArray());
 
         return $contentProductAbstractListTypeTransfer;
     }


### PR DESCRIPTION
In case ContentProductAbstractListTermTransfer is extended and its From extended in ZED all works fine until the data needs to be passed to Yves. Extended parameters should be passed to Yves with this change.

TBD

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
